### PR TITLE
Revised geocoding: Now uses us_cities_merged table

### DIFF
--- a/lib/geocode.py
+++ b/lib/geocode.py
@@ -62,14 +62,14 @@ for scnt in range(-1, c.execute("select max(separator_count(city)) from loctbl.l
     print "------", scnt, "------"
     replace_loc(geocode_replace_loc.domestic_sql()                     % (sep, scnt))
     replace_loc(geocode_replace_loc.domestic_block_remove_sql()        % (sep, scnt))
-    replace_loc(geocode_replace_loc.domestic_first3_jaro_winkler_sql() % (sep, sep, geocode_setup.FIRST3_JARO_REQUIRED, scnt))
-    replace_loc(geocode_replace_loc.domestic_last4_jaro_winkler_sql()  % (sep, sep, geocode_setup.LAST4_JARO_REQUIRED, scnt))
+    replace_loc(geocode_replace_loc.domestic_first3_jaro_winkler_sql() % (sep, sep, geocode_setup.get_jaro_required('domestic_first3'), scnt))
+    replace_loc(geocode_replace_loc.domestic_last4_jaro_winkler_sql()  % (sep, sep, geocode_setup.get_jaro_required('domestic_last4'), scnt))
     replace_loc(geocode_replace_loc.foreign_full_name_1_sql()          % (sep, scnt))
     replace_loc(geocode_replace_loc.foreign_full_name_2_sql()          % (sep, scnt))
     replace_loc(geocode_replace_loc.foreign_short_form_sql()           % (sep, scnt))
     replace_loc(geocode_replace_loc.foreign_block_split_sql()          % (sep, scnt))
-    replace_loc(geocode_replace_loc.foreign_first3_jaro_winkler_sql()  % (sep, sep, "20.92", scnt))
-    replace_loc(geocode_replace_loc.foreign_last4_jaro_winkler_sql()   % (sep, sep, "20.90", scnt))
+    replace_loc(geocode_replace_loc.foreign_first3_jaro_winkler_sql()  % (sep, sep, geocode_setup.get_jaro_required('foreign_first3'), scnt))
+    replace_loc(geocode_replace_loc.foreign_last4_jaro_winkler_sql()   % (sep, sep, geocode_setup.get_jaro_required('foreign_last4'), scnt))
 
 ### End of for loop
 
@@ -77,11 +77,11 @@ print "------ F ------"
 
 # TODO: Put these calls into a function.
 replace_loc(geocode_replace_loc.domestic_2nd_layer_sql())
-replace_loc(geocode_replace_loc.domestic_first3_2nd_jaro_winkler_sql() % ("14.95"))
+replace_loc(geocode_replace_loc.domestic_first3_2nd_jaro_winkler_sql() % (geocode_setup.get_jaro_required('domestic_first3_2nd')))
 replace_loc(geocode_replace_loc.foreign_full_name_2nd_layer_sql())
 replace_loc(geocode_replace_loc.foreign_full_nd_2nd_layer_sql())
 replace_loc(geocode_replace_loc.foreign_no_space_2nd_layer_sql())
-replace_loc(geocode_replace_loc.foreign_first3_2nd_jaro_winkler_sql()  % ("24.95"))
+replace_loc(geocode_replace_loc.foreign_first3_2nd_jaro_winkler_sql()  % (geocode_setup.get_jaro_required('foreign_first3_2nd')))
 replace_loc(geocode_replace_loc.domestic_zipcode_sql())
 
 conn.commit()

--- a/lib/geocode_replace_loc.py
+++ b/lib/geocode_replace_loc.py
@@ -179,7 +179,7 @@ def domestic_last4_jaro_winkler_sql():
 
     print sys._getframe().f_code.co_name
 
-    stmt = """SELECT  (10+jarow(remove_spaces(GET_ENTRY_FROM_ROW(a.City, %d)),
+    stmt = """SELECT  (jarow(remove_spaces(GET_ENTRY_FROM_ROW(a.City, %d)),
                 b.BlkCity)) AS Jaro,
                 a.cnt as cnt,
                 a.city as CityA,

--- a/lib/geocode_replace_loc.py
+++ b/lib/geocode_replace_loc.py
@@ -309,7 +309,7 @@ def foreign_first3_jaro_winkler_sql():
 
     print sys._getframe().f_code.co_name
 
-    stmt = """SELECT  (20+jarow(remove_spaces(GET_ENTRY_FROM_ROW(a.City, %d)),
+    stmt = """SELECT  (jarow(remove_spaces(GET_ENTRY_FROM_ROW(a.City, %d)),
                 b.sort_name_ro)) AS Jaro,
                 a.cnt as cnt,
                 a.city as CityA,
@@ -338,7 +338,7 @@ def foreign_last4_jaro_winkler_sql():
 
     print sys._getframe().f_code.co_name
 
-    stmt = """SELECT  (20+jarow(remove_spaces(GET_ENTRY_FROM_ROW(a.City, %d)),
+    stmt = """SELECT  (jarow(remove_spaces(GET_ENTRY_FROM_ROW(a.City, %d)),
                 b.sort_name_ro)) AS Jaro,
                 a.cnt as cnt,
                 a.city as CityA,
@@ -391,7 +391,7 @@ def domestic_first3_2nd_jaro_winkler_sql():
 
     print sys._getframe().f_code.co_name
 
-    stmt = """SELECT  14+jarow(remove_spaces(a.NCity),
+    stmt = """SELECT  jarow(remove_spaces(a.NCity),
                 b.BlkCity) AS Jaro,
                 a.cnt as cnt,
                 a.city as CityA,
@@ -487,7 +487,7 @@ def foreign_first3_2nd_jaro_winkler_sql():
 
     print sys._getframe().f_code.co_name
 
-    stmt = """SELECT  24+jarow(remove_spaces(a.NCity),
+    stmt = """SELECT  jarow(remove_spaces(a.NCity),
                 b.sort_name_ro) AS Jaro,
                 a.cnt     AS cnt,
                 a.city    AS CityA,

--- a/lib/geocode_replace_loc.py
+++ b/lib/geocode_replace_loc.py
@@ -194,7 +194,7 @@ def domestic_last4_jaro_winkler_sql():
                 b.longitude
           FROM  loc AS a
     INNER JOIN  usloc AS b
-            ON  SUBSTR(remove_spaces(GET_ENTRY_FROM_ROW(a.City, %d)),-4) = b.City4R
+            ON  UPPER(SUBSTR(remove_spaces(GET_ENTRY_FROM_ROW(a.City, %d)),-4)) = b.City4R
            AND  a.state = b.state
            AND  a.country = 'US'
          WHERE  jaro > %s
@@ -353,7 +353,7 @@ def foreign_last4_jaro_winkler_sql():
                 b.long
           FROM  loc AS a
     INNER JOIN  loctbl.gnsloc AS b
-            ON  SUBSTR(remove_spaces(GET_ENTRY_FROM_ROW(a.City, %d)),-4) = b.sort_name_ro
+            ON  UPPER(SUBSTR(remove_spaces(GET_ENTRY_FROM_ROW(a.City, %d)),-4)) = b.sort_name_ro
            AND  a.country = b.cc1
          WHERE  jaro > %s
            AND  separator_count(a.City) >= %d

--- a/lib/geocode_setup.py
+++ b/lib/geocode_setup.py
@@ -4,7 +4,7 @@ import re
 import fwork
 
 FIRST3_JARO_REQUIRED="0.92"
-LAST4_JARO_REQUIRED="10.90"
+LAST4_JARO_REQUIRED="0.90"
 
 def get_first3_jaro_required():
     return FIRST3_JARO_REQUIRED

--- a/lib/geocode_setup.py
+++ b/lib/geocode_setup.py
@@ -6,6 +6,20 @@ import fwork
 FIRST3_JARO_REQUIRED="0.92"
 LAST4_JARO_REQUIRED="0.90"
 
+def get_jaro_required(replacement_operation):
+    if replacement_operation=='domestic_first3':
+        return "0.92"
+    elif replacement_operation=='domestic_last4':
+        return "0.90"
+    elif replacement_operation=='foreign_first3':
+        return "0.92"
+    elif replacement_operation=='foreign_last4':
+        return "0.90"
+    elif replacement_operation=='domestic_first3_2nd':
+        return "0.95"
+    elif replacement_operation=='foreign_first3_2nd':
+        return "0.95"
+
 def get_first3_jaro_required():
     return FIRST3_JARO_REQUIRED
 

--- a/lib/geocode_setup.py
+++ b/lib/geocode_setup.py
@@ -218,7 +218,7 @@ def create_usloc_table(cursor):
                     SUBSTR(remove_spaces(City), -4)        AS City4R,
                     UPPER(State)                       AS State,
                     "US"                               AS Country
-              FROM  loctbl.us_cities;
+              FROM  loctbl.us_cities_merged;
 
         CREATE INDEX If NOT EXISTS usloc_idxZ  on usloc (Zipcode);
         CREATE INDEX If NOT EXISTS usloc_idxCS on usloc (City, State);

--- a/test/process.cfg
+++ b/test/process.cfg
@@ -6,5 +6,5 @@
 # format `ipgYYMMDD` is assumed), then the default parser is used.
 [xml-handlers]
 2005-2012=lib.handlers.grant_handler_v42
-2013=lib.handlers.grant_handler_v43
+2013=lib.handlers.grant_handler_v44
 default=lib.handlers.grant_handler_v42

--- a/test/test_geocode_replace_loc.py
+++ b/test/test_geocode_replace_loc.py
@@ -47,7 +47,7 @@ class TestGeocodeReplaceLoc(unittest.TestCase):
         result = self.cursor.execute(query)
         rows = result.fetchall()
         element = rows[6][6]
-        self.assertTrue('MARION'==element,"{0} should be {1}".format(element,'MARION'))
+        self.assertTrue('LOGAN'==element,"{0} should be {1}".format(element,'LOGAN'))
         pass
 
     def test_domestic_last4_jaro_winkler_sql(self):

--- a/test/test_geocode_setup.py
+++ b/test/test_geocode_setup.py
@@ -61,7 +61,7 @@ class TestGeocodeSetup(unittest.TestCase):
         element = rows[0][0]
         self.assertTrue(0 == element, "{0} should be {1}".format(element,0))
         element = rows[3][3]
-        self.assertTrue('A AND F TRAILER COURT' == element,"{0} should be {1}".format(element, 'A AND F TRAILER COURT'))
+        self.assertTrue('ABEL' == element,"{0} should be {1}".format(element, 'ABEL'))
 
     def tearDown(self):
         pass

--- a/test/test_geocode_setup.py
+++ b/test/test_geocode_setup.py
@@ -3,13 +3,12 @@
 
 import unittest
 import sys
-
-sys.path.append( '.' )
-sys.path.append( '../lib/' )
-
 import sqlite3
 import make_test_databases
-import geocode_setup
+
+sys.path.append( '../' )
+
+import lib.geocode_setup as geocode_setup
 
 
 class TestGeocodeSetup(unittest.TestCase):

--- a/test/test_parse_file.py
+++ b/test/test_parse_file.py
@@ -7,12 +7,10 @@ import logging
 import re
 from collections import Iterable
 
-sys.path.append('..')
-sys.path.append('../lib')
+sys.path.append('../')
 import parse
-from patSQL import *
-sys.path.append('./handlers')
-from grant_handler import PatentGrant
+import lib.patSQL as patSQL
+import lib.handlers.grant_handler_v42 as grant_handler_v42
 
 basedir = os.path.dirname(__file__)
 testdir = os.path.join(basedir, './fixtures/xml/')
@@ -20,8 +18,8 @@ testfileone = 'ipg120327.one.xml'
 testfiletwo = 'ipg120327.two.xml'
 regex = re.compile(r"""([<][?]xml version.*?[>]\s*[<][!]DOCTYPE\s+([A-Za-z-]+)\s+.*?/\2[>])""", re.S+re.I)
 
-xmlclasses = [AssigneeXML, CitationXML, ClassXML, InventorXML, \
-              PatentXML, PatdescXML, LawyerXML, ScirefXML, UsreldocXML]
+xmlclasses = [patSQL.AssigneeXML, patSQL.CitationXML, patSQL.ClassXML, patSQL.InventorXML, \
+              patSQL.PatentXML, patSQL.PatdescXML, patSQL.LawyerXML, patSQL.ScirefXML, patSQL.UsreldocXML]
 
 class TestParseFile(unittest.TestCase):
     
@@ -74,7 +72,7 @@ class TestParseFile(unittest.TestCase):
     def test_use_parse_files_one(self):
         filelist = [testdir+testfileone]
         parsed_output = list(parse.parse_files(filelist))
-        patobj = PatentGrant(parsed_output[0][1], True)
+        patobj = grant_handler_v42.PatentGrant(parsed_output[0][1], True)
         parsed_xml = [xmlclass(patobj) for xmlclass in xmlclasses]
         self.assertTrue(len(parsed_xml) == len(xmlclasses))
         self.assertTrue(all(parsed_xml))
@@ -86,7 +84,7 @@ class TestParseFile(unittest.TestCase):
         for us_patent_grant in parsed_output:
             self.assertTrue(isinstance(us_patent_grant, tuple))
             self.assertTrue(isinstance(us_patent_grant[1], str))
-            patobj = PatentGrant(us_patent_grant[1], True)
+            patobj = grant_handler_v42.PatentGrant(us_patent_grant[1], True)
             for xmlclass in xmlclasses:
                 parsed_xml.append(xmlclass(patobj))
         self.assertTrue(len(parsed_xml) == 2 * len(xmlclasses))


### PR DESCRIPTION
This update requres a new loctbl database, which can be found at https://s3-us-west-1.amazonaws.com/fidownloads/loctbl.7z

The us_cities table was missing a small number of cities. To solve this problem, the usloc table was compressed into a new table, usloc_center_approx, which contains all of the cities in usloc, but compressed to have only a single entry per city - one with the latitude and longitude closest to the center of the city. A subset of this table was merged into the us_cities database to fill the gaps, adding roughly 3,000 cities and forming the new table us_cities_merged, which is now used for the geocoding.

Some code refactoring was also performed.
