### PR TITLE
ignore fake-contents of further_classification if we can't find a tag

### DIFF
--- a/lib/handlers/grant_handler_v42.py
+++ b/lib/handlers/grant_handler_v42.py
@@ -389,12 +389,13 @@ class PatentGrant(object):
         main = self.xml.classification_national.contents_of('main_classification')
         mainclass = [{'class': main[0][:3].replace(' ',''),
                      'subclass': main[0][3:].replace(' ','')}]
-        further = self.xml.classification_national.contents_of('further_classification')
         furtherclasses = []
-        for classification in further:
-            fc = {'class': classification[:3].replace(' ',''),
-                  'subclass': classification[3:].replace(' ','')}
-            furtherclasses.append(fc)
+        if self.xml.classification_national.further_classification:
+            further = self.xml.classification_national.contents_of('further_classification')
+            for classification in further:
+                fc = {'class': classification[:3].replace(' ',''),
+                      'subclass': classification[3:].replace(' ','')}
+                furtherclasses.append(fc)
         return [mainclass, furtherclasses]
 
     def ipcr_classifications(self):

--- a/lib/handlers/grant_handler_v44.py
+++ b/lib/handlers/grant_handler_v44.py
@@ -390,12 +390,13 @@ class PatentGrant(object):
         main = self.xml.classification_national.contents_of('main_classification')
         mainclass = [{'class': main[0][:3].replace(' ',''),
                      'subclass': main[0][3:].replace(' ','')}]
-        further = self.xml.classification_national.contents_of('further_classification')
         furtherclasses = []
-        for classification in further:
-            fc = {'class': classification[:3].replace(' ',''),
-                  'subclass': classification[3:].replace(' ','')}
-            furtherclasses.append(fc)
+        if self.xml.classification_national.further_classification:
+            further = self.xml.classification_national.contents_of('further_classification')
+            for classification in further:
+                fc = {'class': classification[:3].replace(' ',''),
+                      'subclass': classification[3:].replace(' ','')}
+                furtherclasses.append(fc)
         return [mainclass, furtherclasses]
 
     def ipcr_classifications(self):


### PR DESCRIPTION
This is a fix for issue #27, where parsing `<further-classification>` would sometimes incorrectly get data from inside the `<othercit>` tags. It's unclear whether this is an issue in the XML itself or if it's a bug in the XML parser, but because it only affects 4 files, this fix should be sufficient.
