### PR TITLE
Statistics Tables

### DIFF
--- a/lib/alchemy/schema.py
+++ b/lib/alchemy/schema.py
@@ -937,7 +937,7 @@ class USRelDoc(Base):
         return "<USRelDoc('{0}, {1}')>".format(self.number, self.date)
 
 class Claim(Base):
-    __tablename__ = 'claim'
+    __tablename__ = "claim"
     uuid = Column(Unicode(36), primary_key=True)
     patent_id = Column(Unicode(20), ForeignKey('patent.id'))
     text = deferred(Column(UnicodeText))
@@ -946,3 +946,29 @@ class Claim(Base):
 
     def __repr__(self):
         return "<Claim('{0}')>".format(self.text)
+
+class FutureCitationRank(Base):
+    """
+    This table contains the rank of each patent by number of future citations
+    in each year.  A row in this table will read something like "Patent Number
+    X got Y future citations in year Z. It was the Nth most cited patent that
+    year"
+    """
+    __tablename__ = "futurecitationrank"
+    uuid = Column(Unicode(36), primary_key=True)
+    patent_id = Column(Unicode(20), ForeignKey('patent.id'))
+    num_citations = Column(Integer)
+    citation_year = Column(Integer)
+    rank = Column(Integer)
+
+class InventorRank(Base):
+    """
+    This table contains the rank of each inventor by how many patents they
+    have been granted in a given year.
+    """
+    __tablename__ = "inventorrank"
+    uuid = Column(Unicode(36), primary_key=True)
+    inventor_id = Column(Unicode(36), ForeignKey('inventor.id'))
+    num_patents = Column(Integer)
+    patent_year = Column(Integer)
+    rank = Column(Integer)

--- a/lib/alchemy/schema.py
+++ b/lib/alchemy/schema.py
@@ -10,7 +10,6 @@ from unidecode import unidecode
 from sqlalchemy import Table
 import schema_func
 
-# Extend the Base >>>>>>
 Base = declarative_base()
 cascade = "all, delete, delete-orphan"
 
@@ -29,7 +28,6 @@ def init(self, *args, **kwargs):
 
 Base.__init__ = init
 # Base.update = update
-# <<<<<<
 
 # ASSOCIATION ----------------------
 

--- a/statistics.py
+++ b/statistics.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+"""
+Takes the database from the output of integrate.py (e.g. after the disambiguated
+inventors have been merged into the database) and computes statistics on top of it
+"""
+
+import uuid
+from datetime import datetime
+from lib import alchemy
+from collections import Counter, defaultdict
+
+def compute_future_citation_rank():
+    """
+    Ranks each patent by number of future citations in a given year
+    Returns nested dictionary:
+        years[YEAR][PATENT_ID] = number of times PATENT_ID was cited in YEAR
+    """
+    citations = (c for c in alchemy.session.query(alchemy.USPatentCitation).yield_per(1))
+    years = defaultdict(Counter)
+    print "Counting citations...", datetime.now()
+    for cit in citations:
+      if cit.date:
+        year = cit.date.year
+        patid = cit.patent_id
+        years[year][patid] += 1
+    print "Finished counting citations", datetime.now()
+    return years
+
+def insert_future_citation_rank(years):
+    """
+    Accepts as input the dictionary returned from compute_future_citation_rank:
+        years[YEAR][PATENT_ID] = number of times PATENT_ID was cited in YEAR
+    Inserts rows into the correct table:
+    """
+    # remove old rows to make way for new rankings
+    deleted = alchemy.session.query(alchemy.FutureCitationRank).delete()
+    print 'Removed {0} rows from FutureCitationRank'.format(deleted)
+    print 'Inserting records in order...', datetime.now()
+    for year in years.iterkeys():
+        rank = 0
+        prev_num_cits = float('inf')
+        commit_counter = 0
+        for i, record in enumerate(years[year].most_common()):
+            if record[1] < prev_num_cits:
+                prev_num_cits = record[1]
+                rank += 1
+            row = {'uuid': str(uuid.uuid1()),
+                   'patent_id': record[0],
+                   'num_citations': record[1],
+                   'citation_year': year,
+                   'rank': rank}
+            dbrow = alchemy.FutureCitationRank(**row)
+            alchemy.session.merge(dbrow)
+            if (i+1) % 1000 == 0:
+                alchemy.commit()
+    alchemy.commit()
+    print 'Finished inserting records', datetime.now()
+
+
+def compute_inventor_rank():
+    """
+    Ranks each inventor by number of granted patents in a given year
+    Returns nested dictionary:
+        years[YEAR][INVENTOR_ID] = number of patents granted in YEAR to INVENTOR_ID
+    """
+    patents = (p for p in alchemy.session.query(alchemy.Patent).yield_per(1))
+    years = defaultdict(Counter)
+    print 'Counting granted patents...', datetime.now()
+    for pat in patents:
+        year = pat.date.year
+        inventors = pat.inventors
+        for inventor in inventors:
+            years[year][inventor.id] += 1
+    print 'Finished counting', datetime.now()
+    return years
+
+def insert_inventor_rank(years):
+    """
+    Accepts as input the dictionary returned from compute_inventor_rank:
+        years[YEAR][INVENTOR_ID] = number of patents granted in YEAR to INVENTOR_ID
+    Inserts rows into the correct table:
+    """
+    deleted = alchemy.session.query(alchemy.InventorRank).delete()
+    print 'removed {0} rows'.format(deleted)
+    print 'Inserting records in order...', datetime.now()
+    for year in years.iterkeys():
+        rank = 0
+        prev_num_cits = float('inf')
+        commit_counter = 0
+        for i, record in enumerate(years[year].most_common()):
+            if record[1] < prev_num_cits:
+                prev_num_cits = record[1]
+                rank += 1
+            row = {'uuid': str(uuid.uuid1()),
+                   'inventor_id': record[0],
+                   'num_patents': record[1],
+                   'patent_year': year,
+                   'rank': rank}
+            dbrow = alchemy.InventorRank(**row)
+            alchemy.session.merge(dbrow)
+            if (i+1) % 1000 == 0:
+                alchemy.commit()
+    alchemy.commit()
+    print 'Finished inserting records', datetime.now()
+
+
+if __name__=='__main__':
+    years = compute_future_citation_rank()
+    insert_future_citation_rank(years)
+
+    years = compute_inventor_rank()
+    insert_inventor_rank(years)


### PR DESCRIPTION
Implemented the following statistics as requested by Rebecca:
- for each year, rank each patent by how many future citations it received
- for each year, rank each inventor by how many patents they were granted

After the disambiguation step and running `integrate.py` to insert the Inventor IDs into the database, run `statistics.py` to populate the FutureCitationRank and InventorRank tables.
