### PR TITLE
Some claims parsing edge cases

### DIFF
--- a/lib/handlers/xml_driver.py
+++ b/lib/handlers/xml_driver.py
@@ -92,7 +92,7 @@ class XMLElement(object):
                  and len(res) == 1\
                  and isinstance(res[0], list):
                 res = res[0]
-            return ' '.join(filter(lambda x: x, res))
+            return ' '.join(filter(lambda x: x, filter(lambda x: not isinstance(x, list), res)))
         return res
 
     def get_content(self, upper=True):


### PR DESCRIPTION
Came across this weird bug while I was testing application parsing, and don't think it goes well with the applications branch, so I made a separate pull request also just to see if this is what we should do, in, for example, this case that prompted this change: 

![screenshot from 2013-11-13 12 08 21](https://f.cloud.github.com/assets/2067277/1535287/c190bdae-4ca1-11e3-8239-615b55461da0.png)

A little below halfway down the screenshot is the claims list causing the error: there's a weird list of attributes that somehow gets pulled into there.
